### PR TITLE
SecondaryIndexQuery command and tests.

### DIFF
--- a/lib/commands/kv/riakobject.js
+++ b/lib/commands/kv/riakobject.js
@@ -164,7 +164,7 @@ RiakObject.prototype = {
      * Set an index, replacing the existing value is any.
      * @method setIndex
      * @param {String} indexName the index name
-     * @param {String[]} arrayOfKeys - the keys 
+     * @param {String[]|Number[]} arrayOfKeys - the keys 
      * @chainable
      */
     setIndex : function(indexName, arrayOfKeys) {
@@ -209,7 +209,7 @@ RiakObject.prototype = {
      * If the index does not exist it will be created.
      * @method addToIndex
      * @param {String} indexName the index name
-     * @param {String} ...key 1 or more keys to add
+     * @param {String|Number} ...key 1 or more keys to add
      * @chainable
      */
     addToIndex : function(indexName, key) {
@@ -266,6 +266,10 @@ RiakObject.prototype = {
 
 module.exports = RiakObject;
 
+module.exports.isIntIndex = function(indexName) {
+    return indexName.indexOf('_int', indexName.length - 4) !== -1;
+};
+
 module.exports.createFromRpbContent = function(rpbContent, convertToJs) {
 
     var ro = new RiakObject();
@@ -312,7 +316,12 @@ module.exports.createFromRpbContent = function(rpbContent, convertToJs) {
             if (!indexes.hasOwnProperty(indexName)) {
                 indexes[indexName] = [];
             }
-            indexes[indexName].push(pbIndexes[i].value.toString('utf8'));
+            var stringValue = pbIndexes[i].value.toString('utf8');
+            if (RiakObject.isIntIndex(indexName)) {
+                indexes[indexName].push(parseInt(stringValue));
+            } else {
+                indexes[indexName].push(stringValue);
+            }
         }
         ro.indexes = indexes;
     }
@@ -355,7 +364,8 @@ module.exports.populateRpbContentFromRiakObject = function(ro) {
             for (var i = 0; i < indexKeys.length; i++) {
                 var pair = new RpbPair();
                 pair.setKey(new Buffer(indexName));
-                pair.setValue(new Buffer(indexKeys[i]));
+                // The Riak API expects string values, even for _int indexes
+                pair.setValue(new Buffer(indexKeys[i].toString()));
                 rpbContent.indexes.push(pair);
             }
         }

--- a/lib/commands/kv/secondaryindexquery.js
+++ b/lib/commands/kv/secondaryindexquery.js
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2015 Basho Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+var CommandBase = require('../commandbase');
+var inherits = require('util').inherits;
+var Joi = require('joi');
+var RpbIndexReq = require('../../protobuf/riakprotobuf').getProtoFor('RpbIndexReq');
+var RpbPair = require('../../protobuf/riakprotobuf').getProtoFor('RpbPair');
+var RiakObject = require('./riakobject');
+
+/**
+ * Provides the SecondaryIndexQuery class and its builder.
+ * @module SecondaryIndexQuery
+ */
+
+
+/**
+ * Command used to perform a secondary index query. 
+ * 
+ * As a convenience, a builder class is provided:
+ * 
+ *     var SecondaryIndexQuery = require('lib/commands/kv/secondaryindexquery');
+ *     var query = new SecondaryIndexQuery.Builder()
+ *                  .withBucket('myBucket')
+ *                  .withIndexName('email_bin')
+ *                  .withIndexKey('roach@basho.com')
+ *                  .withCallback(myCallback)
+ *                  .build();
+ *                  
+ * @class SecondaryIndexQuery
+ * @constructor   
+ * @param {Object} options options for this command.
+ * @param {String} [options.bucketType] the bucket type in riak.
+ * @param {String} options.bucket the bucket in riak.
+ * @param {Function} options.callback the callback to be executed by the command.
+ * @param {String} options.callback.err  An error message
+ * @param {Object[]} options.callback.response object keys returned by the query, and optionally the index keys.
+ * @param {Boolean} options.callback.done if you have received all the results.
+ * @param {Buffer} options.callback.continuation if a continuation was returned
+ * @param {String|Number} [options.indexKey] a single index key to query
+ * @param {String|Number} [options.rangeStart] Starting key for a range query
+ * @param {String|Number} [options.rangeEnd] Ending key for a range query
+ * @param {Boolean} [options.returnKeyAndIndex=false] return the index keys along with the object keys
+ * @param {Number} [options.maxResults] limit the results returned and paginate if necessary
+ * @param {Buffer} [options.continuation] returned from a previous query that set maxResults. used for pagination.
+ * @param {Boolean} [options.stream=true] whether to stream or accumulate the result before calling callback.
+ * @param {Number} [options.timeout] set a timeout for this operation.
+ * @param {Boolean} [options.paginationSort=false] true to sort a non-paginated query. 
+ * @extends CommandBase
+ */
+function SecondaryIndexQuery(options) {
+    CommandBase.call(this, 'RpbIndexReq', 'RpbIndexResp');
+    
+    var self = this;
+    Joi.validate(options, schema, function(err, options) {
+       
+        if (err) {
+            throw err;
+        }
+    
+        // I tried making this work in the Joi schema and finally gave up. It seems
+        // alternatives can't work with multiple conditionals.
+        if (options.indexKey === null && (options.rangeStart === null || options.rangeEnd === null) ) {
+            throw ('either \'indxKey\' or \'rangeStart\' + \'rangeEnd\' are required');
+        } 
+    
+        self.options = options;
+    });
+    
+    
+    
+    this.remainingTries = 1;
+    
+    if (!this.options.stream) {
+        this.responses = [];
+    }
+}
+
+inherits(SecondaryIndexQuery, CommandBase);
+
+SecondaryIndexQuery.prototype.constructPbRequest = function() {
+  
+    var protobuf = this.getPbReqBuilder();
+    // We always stream from Riak. 
+    protobuf.setStream(true);
+    
+    protobuf.setBucket(new Buffer(this.options.bucket));
+    protobuf.setType(new Buffer(this.options.bucketType));
+    protobuf.setIndex(new Buffer(this.options.indexName));
+    protobuf.setReturnTerms(this.options.returnKeyAndIndex);
+    
+    if (this.options.indexKey !== null) {
+        // _int index requests take ... strings, not numbers
+        protobuf.setKey(new Buffer(this.options.indexKey.toString()));
+        protobuf.setQtype(RpbIndexReq.IndexQueryType.eq);
+    } else {
+        protobuf.setRangeMin(new Buffer(this.options.rangeStart.toString()));
+        protobuf.setRangeMax(new Buffer(this.options.rangeEnd.toString()));
+        protobuf.setQtype(RpbIndexReq.IndexQueryType.range);
+    }
+    
+    if (!this.options.maxResults && this.options.paginationSort) {
+        protobuf.setPaginationSort(this.options.paginationSort);
+    }
+    protobuf.setMaxResults(this.options.maxResults);
+    protobuf.setContinuation(this.options.continuation);
+    protobuf.setTimeout(this.options.timeout);
+    
+    return protobuf;
+};
+
+SecondaryIndexQuery.prototype.onSuccess = function(rpbIndexResp) {
+    
+    /**
+    * The 2i API is inconsistent on the Riak side. If it's not 
+    * a range query, return_terms is ignored it only returns the 
+    * list of object keys and you have to have
+    * preserved the index key if you want to return it to the user
+    * with the results. 
+    * 
+    * Also, the $key index queries just ignore return_terms altogether.
+    */
+   
+   
+    if (rpbIndexResp.results.length) {
+        // Index keys and object keys were returned
+        var resultsToReturn = new Array(rpbIndexResp.results.length);
+        for (var i = 0; i < rpbIndexResp.results.length; i++) {
+            var iKey = rpbIndexResp.results[i].key.toString('utf8');
+            if (RiakObject.isIntIndex(this.options.indexName)) {
+                iKey = parseInt(iKey);
+            }
+            resultsToReturn[i] = { indexKey : iKey,
+                                  objectKey : rpbIndexResp.results[i].value.toString('utf8') };
+        }
+    } else {
+        // only object keys were returned
+        var resultsToReturn = new Array(rpbIndexResp.keys.length);
+        for (var i = 0; i < rpbIndexResp.keys.length; i++) {
+            var key = null;
+            if (this.options.returnKeyAndIndex) {
+                // this is only possible if this was a single key query
+                key = this.options.indexKey;
+            }
+            resultsToReturn[i] = { indexKey: key, objectKey: rpbIndexResp.keys[i].toString('utf8') };
+        }
+    }
+    
+    
+    var continuation = rpbIndexResp.continuation;
+    
+    if (this.options.stream) {
+        this.options.callback(null, resultsToReturn, rpbIndexResp.done, continuation );
+    } else {
+        Array.prototype.push.apply(this.responses, resultsToReturn);
+        if (rpbIndexResp.done) {
+            this.options.callback(null, this.responses, true, continuation);
+        }
+    }
+    
+    return rpbIndexResp.done;
+    
+};
+
+SecondaryIndexQuery.prototype.onRiakError = function(rpbErrorResp) {
+    this.onError(rpbErrorResp.getErrmsg().toString('utf8'));
+};
+    
+    
+SecondaryIndexQuery.prototype.onError = function(msg) {
+    this.options.callback(msg, null);
+};
+
+
+// Explicitly set null on options for protobufs and for conditionals
+var schema = Joi.object().keys({
+   bucket: Joi.string().required(),
+   bucketType: Joi.string().default('default'),
+   indexName: Joi.string().required(),
+   indexKey: Joi.alternatives().try(Joi.number(), Joi.string()).default(null).optional(),
+   rangeStart: Joi.alternatives().try(Joi.number(), Joi.string()).default(null).optional(),
+   rangeEnd: Joi.alternatives().try(Joi.number(), Joi.string()).default(null).optional(),
+   returnKeyAndIndex: Joi.boolean().default(null).optional(),
+   maxResults: Joi.number().default(null).optional(),
+   continuation: Joi.any().default(null).optional(),
+   callback: Joi.func().required(),
+   timeout: Joi.number().default(null).optional(),
+   stream: Joi.boolean().default(true).optional(),
+   paginationSort: Joi.boolean().default(null).optional()
+});
+
+
+/**
+ * A builder for constructing SecondaryIndexquery instances.
+ * * Rather than having to manually construct the __options__ and instantiating
+ * a SecondaryIndexQuery directly, this builder may be used.
+ * 
+ *      var SecondaryIndexQuery = require('lib/commands/kv/secondaryindexquery');
+ *      var query = new SecondaryIndexQuery.Builder()
+ *                  .withBucket('myBucket')
+ *                  .withIndexName('email_bin')
+ *                  .withIndexKey('roach@basho.com')
+ *                  .withCallback(myCallback)
+ *                  .build();
+ *       
+ * @namespace SecondaryIndexQuery
+ * @class Builder
+ * @constructor
+ */
+function Builder() {}
+
+Builder.prototype = {
+    
+    /**
+     * Set the bucket.
+     * @method withBucket
+     * @param {String} bucket the bucket in Riak
+     * @chainable
+     */
+    withBucket : function(bucket) {
+        this.bucket = bucket;
+        return this;
+    },
+    /**
+     * Set the bucket type.
+     * If not supplied, 'default' is used.
+     * @method withBucketType
+     * @param {String} bucketType the bucket type in riak
+     * @chainable
+     */
+    withBucketType : function(bucketType) {
+        this.bucketType = bucketType;
+        return this;
+    },
+    /**
+     * Set the index name
+     * @method
+     * @param {String} indexName the index to query
+     * @chainable
+     */
+    withIndexName : function(indexName) {
+        this.indexName = indexName;
+        return this;
+    },
+    /**
+     * Set a single secondary index key to use for query.
+     * Note that you can only set a single key, or a range. 
+     * @method withIndexKey
+     * @param {String|Number} indexKey the secondary index key.
+     * @chainable
+     */
+    withIndexKey : function(indexKey) {
+        this.indexKey = indexKey;
+        return this;
+    },
+    /**
+     * Set a range for the query
+     * @method withRange
+     * @param {String|Number} start the start of the range
+     * @param {String|Number} end the end of the range
+     * @chainable
+     */
+    withRange : function(start, end) {
+        this.rangeStart = start;
+        this.rangeEnd = end;
+        return this;
+    },
+    /**
+     * Set whether to return the index keys with the Riak object keys.
+     * Setting this to true will return both the index key and the Riak
+     * object's key. The default is false (only to return the Riak object keys).
+     * @method withReturnKeyAndIndex
+     * @param {Boolean} returnKeyAndIndex whether to return the index keys as well
+     * @chainable
+     */
+    withReturnKeyAndIndex : function(returnKeyAndIndex) {
+        this.returnKeyAndIndex = returnKeyAndIndex;
+        return this;
+    },
+    /**
+     * Set the maximum number of results returned by the query.
+     * 
+     * When asking for large result sets, it is often desirable to ask the 
+     * servers to return chunks of results instead of a firehose. 
+     * You can do so using this method, where maxResults is the number of 
+     * results you'd like to receive.
+     * 
+     * Assuming more keys are available, a continuation value will be included 
+     * in the results to allow the client to request the next page.
+     * @method withMaxResults
+     * @param {Number} maxResults the max number of results to return.
+     * @chainable
+     */
+    withMaxResults : function(maxResults) {
+        this.maxResults = maxResults;
+        return this;
+    },
+    /**
+     * Set the continuation for this query.
+     * If using pagination via maxResults, this will have been returned
+     * by a previous query.
+     * @method withContinuation
+     * @param {Buffer} continuation the continuation from a previous query
+     * @chainable
+     */
+    withContinuation : function(continuation) {
+        this.continuation = continuation;
+        return this;
+    },
+    /**
+    * Set a timeout for this operation.
+    * @method withTimeout
+    * @param {Number} timeout a timeout in milliseconds.
+    * @chainable
+    */
+    withTimeout : function(timeout) {
+        this.timeout = timeout;
+        return this;
+    },
+    /**
+     * Set the callback to be executed when the operation completes.
+     * @method withCallback
+     * @param {Function} callback - the callback to execute
+     * @param {String} callback.err An error message
+     * @param {SecondaryIndexQuery.Response} callback.response - the response from Riak
+     * @chainable
+     */
+    withCallback : function(callback) {
+        this.callback = callback;
+        return this;
+    },
+    /**
+     * Stream the results.
+     * Setting this to true will cause you callback to be called as the results
+     * are returned from Riak. Set to false the result set will be buffered and 
+     * delevered via a single call to your callback. Note that on large result sets 
+     * this is very memory intensive.
+     * @method withStreaming
+     * @param {Boolean} [stream=true] Set whether or not to stream the results 
+     * @chainable
+     */
+    withStreaming : function(stream) {
+        this.stream = stream;
+        return this;
+    },
+    /**
+     * Set whether to sort the results of a non-paginated 2i query.
+     * If you are not using pagination (setting withMaxResults()) the 
+     * default behavior in Riak is to not sort the result set.
+     * Setting this to true will sort the results before returning them.
+     * __Note that this is not recommended for queries that could return a large
+     * result set; the overhead in Riak is substantial. __
+     * @method withPaginationSort
+     * @param {Boolean} paginationSort true to sort the results of a non-paginated query
+     * @chainable
+     */
+    withPaginationSort : function(paginationSort) {
+        this.paginationSort = paginationSort;
+        return this;
+    },
+    /**
+     * Construct a SecondaryIndexQuery instance
+     * @method build
+     * @return {SecondaryIndexQuery}
+     */
+    build : function() {
+        return new SecondaryIndexQuery(this);
+    }
+    
+};
+
+module.exports = SecondaryIndexQuery;
+module.exports.Builder = Builder;

--- a/lib/core/riaknode.js
+++ b/lib/core/riaknode.js
@@ -248,11 +248,16 @@ RiakNode.prototype._responseReceived = function(conn, command, code, decoded) {
             command.onError(msg);
         }
     } else {
-        var done = command.onSuccess(decoded);
-        if (done) {
+        // All of our responses that return multiple protobuf messages (streaming) use 
+        // a "done" field. Checking for it allows us to know when a streaming op is done and
+        // return the connections to the pool before calling the callback.
+        // Some responses will be empty (null body), so we also need to account for that.
+        var hasDone = decoded ? decoded.hasOwnProperty('done') : false;
+        if ( (hasDone && decoded.done) || !hasDone) {
             logger.info('Riaknode (%s:%d): command complete', this.remoteAddress, this.remotePort);
             this._returnConnectionToPool(conn);
         }
+        command.onSuccess(decoded);
     }
     
 };

--- a/test/unit/secondaryindexquery.js
+++ b/test/unit/secondaryindexquery.js
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2015 Basho Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var SecondaryIndexQuery = require('../../lib/commands/kv/secondaryindexquery');
+var RpbIndexResp = require('../../lib/protobuf/riakprotobuf').getProtoFor('RpbIndexResp');
+var RpbIndexReq = require('../../lib/protobuf/riakprotobuf').getProtoFor('RpbIndexReq');
+var RpbErrorResp = require('../../lib/protobuf/riakprotobuf').getProtoFor('RpbErrorResp');
+var RpbPair = require('../../lib/protobuf/riakprotobuf').getProtoFor('RpbPair');
+var assert = require('assert');
+
+describe('SecondaryIndexQuery', function() {
+    describe('Build', function() {
+        it('should build a RpbIndexReq correctly for a single key query', function(done) {
+            
+            var siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('email_bin')
+                    .withIndexKey('roach@basho.com')
+                    .withCallback(function(){})
+                    .withTimeout(20000)
+                    .withReturnKeyAndIndex(true)
+                    .withMaxResults(20)
+                    .withContinuation(new Buffer('1234'))
+                    .build();
+            
+            var protobuf = siq.constructPbRequest();
+            
+            assert.equal(protobuf.getType().toString('utf8'), 'default');
+            assert.equal(protobuf.getBucket().toString('utf8'), 'MyBucket');
+            // We should always be streaming from Riak
+            assert.equal(protobuf.stream, true);
+            assert.equal(protobuf.timeout, 20000);
+            assert.equal(protobuf.getKey().toString('utf8'), 'roach@basho.com');
+            assert.equal(protobuf.getRangeMin(), null);
+            assert.equal(protobuf.getRangeMax(), null);
+            assert.equal(protobuf.getIndex().toString('utf8'), 'email_bin');
+            assert.equal(protobuf.getReturnTerms(), true);
+            assert.equal(protobuf.getContinuation().toString('utf8'), '1234');
+            assert.equal(protobuf.getQtype(), RpbIndexReq.IndexQueryType.eq);
+            assert.equal(protobuf.getMaxResults(), 20);
+            done();
+            
+            
+        });
+        
+        it('should build a RpbIndexReq correctly for a range query', function(done) {
+            
+            var siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('id_int')
+                    .withRange(0,50)
+                    .withCallback(function(){})
+                    .withTimeout(20000)
+                    .withReturnKeyAndIndex(true)
+                    .withMaxResults(20)
+                    .withContinuation(new Buffer('1234'))
+                    .build();
+            
+            var protobuf = siq.constructPbRequest();
+            
+            assert.equal(protobuf.getType().toString('utf8'), 'default');
+            assert.equal(protobuf.getBucket().toString('utf8'), 'MyBucket');
+            // We should always be streaming from Riak
+            assert.equal(protobuf.stream, true);
+            assert.equal(protobuf.timeout, 20000);
+            assert.equal(protobuf.getIndex().toString('utf8'), 'id_int');
+            assert.equal(protobuf.getReturnTerms(), true);
+            assert.equal(protobuf.getContinuation().toString('utf8'), '1234');
+            assert.equal(protobuf.getQtype(), RpbIndexReq.IndexQueryType.range);
+            assert.equal(protobuf.getKey(), null);
+            // Riak's API expects strings, not numbers, for _int index queries
+            // The command converts them
+            assert.equal(protobuf.getRangeMin().toString('utf8'), '0');
+            assert.equal(protobuf.getRangeMax().toString('utf8'), '50');
+            done();
+        });
+        
+        it('maxResults should override paginationSort', function(done) {
+            
+            var siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('id_int')
+                    .withRange(0,50)
+                    .withCallback(function(){})
+                    .withMaxResults(20)
+                    .withPaginationSort(true)
+                    .build();
+            
+            var protobuf = siq.constructPbRequest();
+            
+            assert.equal(protobuf.getPaginationSort(), null);
+            
+            siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('id_int')
+                    .withRange(0,50)
+                    .withCallback(function(){})
+                    .withPaginationSort(true)
+                    .build();
+            
+            protobuf = siq.constructPbRequest();
+            
+            assert.equal(protobuf.getPaginationSort(), true);
+            done();
+            
+        });
+        
+        it('requires either an indexKey or rangeStart + rangeEnd', function(done) {
+           
+           assert.throws(
+                function() { var siq = new SecondaryIndexQuery.Builder()
+                            .withBucket('MyBucket')
+                            .withIndexName('id_int')
+                            .withCallback(function(){})
+                            .build();
+                },
+                'either \'indxKey\' or \'rangeStart\' + \'rangeEnd\' are required'
+            );
+            done();
+            
+        });
+        
+        it('indexKey overrides range if both supplied', function(done) {
+           
+            var siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('id_int')
+                    .withIndexKey(5)
+                    .withRange(0,50)
+                    .withCallback(function(){})
+                    .build();
+            
+            var protobuf = siq.constructPbRequest();
+            
+            assert.equal(protobuf.getKey().toString('utf8'), '5');
+            assert.equal(protobuf.getRangeMin(), null);
+            assert.equal(protobuf.getRangeMax(), null);
+            assert.equal(protobuf.getQtype(), RpbIndexReq.IndexQueryType.eq);
+            done();
+            
+        });
+        
+        it('should take multiple RpbIndexResp with just object keys and call the users callback with the response', function(done) {
+            
+            var callback = function(err, response, complete, continuation) {
+                
+                assert.equal(response.length, 100);
+                assert.equal(response[0].indexKey, null);
+                assert.equal(response[0].objectKey, 'object_key');
+                assert.equal(complete, true);
+                assert.equal(continuation.toString('utf8'), '1234');
+                done();
+            };
+            
+            var siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('id_bin')
+                    .withCallback(callback)
+                    .withStreaming(false)
+                    .withRange(0,50)
+                    .build();
+            
+            for (var i = 0; i < 20; i++) {
+                var indexResp = new RpbIndexResp();    
+                for (var j = 0; j < 5; j++) {
+                    indexResp.keys.push(new Buffer('object_key'));
+                }
+                if (i === 19) {
+                    indexResp.done = true;
+                    indexResp.continuation = new Buffer('1234');
+                }
+                siq.onSuccess(indexResp);
+            }
+        });
+        
+        it('should take multiple RpbIndexResp with term/key pairs and call the users callback with the response', function(done) {
+            
+            var callback = function(err, response, complete, continuation) {
+                
+                assert.equal(response.length, 100);
+                assert.equal(response[0].indexKey, 'index_key');
+                assert.equal(response[0].objectKey, 'object_key');
+                assert.equal(complete, true);
+                assert.equal(continuation.toString('utf8'), '1234');
+                done();
+            };
+            
+            var siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('id_bin')
+                    .withCallback(callback)
+                    .withStreaming(false)
+                    .withReturnKeyAndIndex(true)
+                    .withRange(0, 50)
+                    .build();
+            
+            for (var i = 0; i < 20; i++) {
+                var indexResp = new RpbIndexResp();    
+                for (var j = 0; j < 5; j++) {
+                    var pair = new RpbPair();
+                    pair.key = new Buffer('index_key');
+                    pair.value = new Buffer('object_key');
+                    indexResp.results.push(pair);
+                }
+                if (i === 19) {
+                    indexResp.done = true;
+                    indexResp.continuation = new Buffer('1234');
+                }
+                siq.onSuccess(indexResp);
+            }
+        });
+        
+        it('should take multiple RpbIndexResp with just object keys and stream the response', function(done) {
+            
+            var count = 0;
+            var timesCalled = 0;
+            var callback = function(err, response, complete, continuation) {
+                
+                timesCalled++;
+                count += response.length;
+                
+                assert.equal(response[0].indexKey, null);
+                assert.equal(response[0].objectKey, 'object_key');
+                
+                
+                if (complete) {
+                    assert.equal(timesCalled, 20);
+                    assert.equal(count, 100);
+                    assert.equal(continuation.toString('utf8'), '1234');
+                    done();
+                }
+            };
+            
+            var siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('id_int')
+                    .withCallback(callback)
+                    .withStreaming(true)
+                    .withRange(0, 50)
+                    .build();
+            
+            for (var i = 0; i < 20; i++) {
+                var indexResp = new RpbIndexResp();    
+                for (var j = 0; j < 5; j++) {
+                    indexResp.keys.push(new Buffer('object_key'));
+                }
+                if (i === 19) {
+                    indexResp.done = true;
+                    indexResp.continuation = new Buffer('1234');
+                }
+                siq.onSuccess(indexResp);
+            }
+        });
+        
+        it('should take multiple RpbIndexResp with term/key pairs and stream the response', function(done) {
+            
+            var count = 0;
+            var timesCalled = 0;
+            var callback = function(err, response, complete, continuation) {
+                timesCalled++;
+                count += response.length;
+                
+                assert.equal(response[0].indexKey, 123);
+                assert.equal(response[0].objectKey, 'object_key');
+                
+                
+                if (complete) {
+                    assert.equal(timesCalled, 20);
+                    assert.equal(count, 100);
+                    assert.equal(continuation.toString('utf8'), '1234');
+                    done();
+                }
+            };
+            
+            var siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('id_int')
+                    .withCallback(callback)
+                    .withStreaming(true)
+                    .withReturnKeyAndIndex(true)
+                    .withRange(0, 50)
+                    .build();
+            
+            for (var i = 0; i < 20; i++) {
+                var indexResp = new RpbIndexResp();    
+                for (var j = 0; j < 5; j++) {
+                    var pair = new RpbPair();
+                    pair.key = new Buffer('123');
+                    pair.value = new Buffer('object_key');
+                    indexResp.results.push(pair);
+                }
+                if (i === 19) {
+                    indexResp.done = true;
+                    indexResp.continuation = new Buffer('1234');
+                }
+                siq.onSuccess(indexResp);
+            }
+        });
+        
+        it ('should take a RpbErrorResp and call the users callback with the error message', function(done) {
+           var rpbErrorResp = new RpbErrorResp();
+           rpbErrorResp.setErrmsg(new Buffer('this is an error'));
+           
+           var callback = function(err, response) {
+               if (err) {
+                   assert.equal(err,'this is an error');
+                   done();
+               }
+           };
+           
+           var siq = new SecondaryIndexQuery.Builder()
+                    .withBucket('MyBucket')
+                    .withIndexName('id_bin')
+                    .withCallback(callback)
+                    .withStreaming(false)
+                    .withReturnKeyAndIndex(true)
+                    .withRange(0,50)
+                    .build();
+            
+            siq.onRiakError(rpbErrorResp);
+           
+           
+       });
+        
+    });
+});
+    


### PR DESCRIPTION
Also some changes to RiakObject to account for the goofy way
the 2i PB API works (everything is a string, even if it's
number for a _int index)
