### PR TITLE
CLIENTS-297: TLS/Auth now handles RpbErrorResp

### DIFF
--- a/lib/core/riakconnection.js
+++ b/lib/core/riakconnection.js
@@ -81,7 +81,7 @@ RiakConnection.prototype.connect = function() {
 };
 
 RiakConnection.prototype._connected = function() {
-    logger.info("Connected; host: " + this.remoteAddress + 
+    logger.info("RiakConnection: Connected; host: " + this.remoteAddress + 
                 " port: " + this.remotePort);
 
     this._connection.removeListener('error', this._boundConnectionError);
@@ -105,7 +105,7 @@ RiakConnection.prototype._connected = function() {
 
 RiakConnection.prototype._connectionError = function(err) {
     // Connection error, emit to listener
-    logger.error("Failed to connect;" + 
+    logger.error("RiakConnection: Failed to connect;" + 
                 this.remoteAddress + 
                 " port: " + this.remotePort + 
                 " error: " + err);
@@ -114,58 +114,60 @@ RiakConnection.prototype._connectionError = function(err) {
 };
     
 RiakConnection.prototype._connectionTimeout = function() {
-    this._connectionError('Timed out trying to connect');
+    this._connectionError('RiakConnection Timed out trying to connect');
 };
     
 RiakConnection.prototype._socketError = function(err) {
     // This is only called if we have an error after a successful connection
     // log only because close will be called right after
-    logger.error("Socket error; " + err);
+    logger.error("RiakConnection: Socket error; " + err);
 };
     
 RiakConnection.prototype._receiveStartTls = function(data) {
 
     logger.debug("RiakConnection:_receiveStartTls");
 
-    this._ensureExpectedResponse(data, 'RpbStartTls');
+    if (this._ensureExpectedResponse(data, 'RpbStartTls')) {
 
-    var tls_secure_context = tls.createSecureContext(this.auth);
-    var tls_socket_options = {
-        isServer: false, // NB: required
-        secureContext: tls_secure_context,
-    };
+        var tls_secure_context = tls.createSecureContext(this.auth);
+        var tls_socket_options = {
+            isServer: false, // NB: required
+            secureContext: tls_secure_context
+        };
 
-    this._connection = new tls.TLSSocket(this._connection, tls_socket_options);
+        this._connection = new tls.TLSSocket(this._connection, tls_socket_options);
 
-    var auth_options = {
-        user: this.auth.user,
-        password: this.auth.password,
-    };
+        var auth_options = {
+            user: this.auth.user,
+            password: this.auth.password
+        };
 
-    // On data, move to next sequence in TLS negotiation
-    this._connection.removeListener('data', this._boundReceiveStartTls);
-    this._boundReceiveAuthResp = this._receiveAuthResp.bind(this);
-    this._connection.on('data', this._boundReceiveAuthResp);
+        // On data, move to next sequence in TLS negotiation
+        this._connection.removeListener('data', this._boundReceiveStartTls);
+        this._boundReceiveAuthResp = this._receiveAuthResp.bind(this);
+        this._connection.on('data', this._boundReceiveAuthResp);
 
-    // Execute AuthReq command
-    this.inFlight = false;
-    var command = new AuthReq(auth_options);
-    this.execute(command);
+        // Execute AuthReq command
+        this.inFlight = false;
+        var command = new AuthReq(auth_options);
+        this.execute(command);
+    }
 };
 
 RiakConnection.prototype._receiveAuthResp = function(data) {
 
-    this._ensureExpectedResponse(data, 'RpbAuthResp');
+    if (this._ensureExpectedResponse(data, 'RpbAuthResp')) {
 
-    // On data, use the _receiveData function
-    this._connection.removeListener('data', this._boundReceiveAuthResp);
-    this._connection.on('data', this._receiveData.bind(this));
-    this._connection.setTimeout(0);
+        // On data, use the _receiveData function
+        this._connection.removeListener('data', this._boundReceiveAuthResp);
+        this._connection.on('data', this._receiveData.bind(this));
+        this._connection.setTimeout(0);
 
-    this.inFlight = false;
+        this.inFlight = false;
 
-    logger.debug('RiakConnection:emit:connected:yes-auth');
-    this.emit('connected', this);
+        logger.debug('RiakConnection:emit:connected:yes-auth');
+        this.emit('connected', this);
+    }
 
 };
 
@@ -183,18 +185,28 @@ RiakConnection.prototype._receiveData = function(data) {
 RiakConnection.prototype._ensureExpectedResponse = function(data, msgName) {
 
     var protobufArray = this._buildProtobufArray(data);
+    var err;
     if (protobufArray.length === 0) {
-        throw new Error('Expected ' + msgName + ' response message');
-    }
+        err = 'Expected ' + msgName + ' response message';
+    } else {
 
-    var resp = protobufArray[0];
-    var code = RiakProtoBuf.getCodeFor(msgName);
-    if (resp.msgCode !== code) {
-        var err = msgName + ' incorrect response code: ' + resp.msgCode;
-        logger.error(err);
-        throw new Error(err);
+        var resp = protobufArray[0];
+        var code = RiakProtoBuf.getCodeFor(msgName);
+        
+        if (resp.msgCode === 0) {
+            // We received an RpbErrorResp
+            err = resp.protobuf.getErrmsg().toString('utf8');
+        } else if (resp.msgCode !== code) {
+            err = msgName + ' incorrect response code: ' + resp.msgCode;
+        }
     }
-
+    
+    if (err) {
+        this._connectionError(err);
+        return false;
+    } else {
+        return true;
+    }
 };
     
 RiakConnection.prototype._buildProtobufArray = function(data) {
@@ -283,7 +295,7 @@ RiakConnection.prototype.close = function() {
 RiakConnection.prototype.execute = function(command) {
     this.command = command;
     if (this.inFlight === true) {
-        logger.error("Attempted to run command on in-use connection");
+        logger.error("RiakConnection: Attempted to run command on in-use connection");
         return false;
     }
     logger.debug("RiakConnection:execute:command: " + command.PbRequestName);


### PR DESCRIPTION
If security isn't enabled, or auth fails, the RiakConnection now
emits a 'connectFailed' with the appropriate error message and
destroys itself. The error message is propagated up to the command's
onError() callback.