### PR TITLE
Command queueing option for RiakCluster

### DIFF
--- a/lib/core/riakcluster.js
+++ b/lib/core/riakcluster.js
@@ -20,6 +20,7 @@ var events = require('events');
 var logger = require('winston');
 var Joi = require('joi');
 var util = require('util');
+var LinkedList = require('linkedlist');
 
 /**
  * @module Core
@@ -54,6 +55,10 @@ var util = require('util');
  * @param {Object} options - the options to use.
  * @param {RiakNode[]} options.nodes An array of (unstarted) {{#crossLink "RiakNode"}}{{/crossLink}} objects.
  * @param {Number} [options.executionAttempts=3] Number of times to retry commands on failure.
+ * @param {Object} [options.nodeManager=DefaultNodeManager] Set the NodeManager for this cluster.
+ * @param {Boolean} [options.queueCommands=false] Set whether to queue commands or not if no RiakNodes are available.
+ * @param {Number} [options.queueMaxDepth=unlimited] The maximum number of commands to queue if queueCommands is set. Default is unlimited.
+ * 
  */
 function RiakCluster(options) {
     
@@ -73,9 +78,11 @@ function RiakCluster(options) {
         self.executionAttempts = options.executionAttempts;
         self.state = State.CREATED;
         self.nodeManager = options.nodeManager;
+        self.queueCommands = options.queueCommands;
+        self.queueMaxDepth = options.queueMaxDepth;
     });
     
-    this._nodeIndex = 0;
+    this._commandQueue = new LinkedList();
     
 }
 
@@ -111,7 +118,7 @@ RiakCluster.prototype.start = function() {
  * @method stop
  */
 RiakCluster.prototype.stop = function() {
-    this._stateCheck([State.RUNNING]);
+    this._stateCheck([State.RUNNING, State.QUEUEING]);
     
     logger.debug('RiakCluster is shutting down');
     this.state = State.SHUTTING_DOWN;
@@ -135,6 +142,10 @@ RiakCluster.prototype._shutdown = function () {
     if (allStopped) {
         this.state = State.SHUTDOWN;
         logger.debug('[RiakCluster] cluster shut down.');
+        if (this._commandQueue.length) {
+            logger.warn('[RiakCluster] There were %d commands in the queue at shutdown', 
+                this._commandQueue.length);
+        }
         this.emit('stateChange', this.state);
     } else {
         logger.debug('[RiakCluster] nodes still running.');
@@ -159,13 +170,54 @@ RiakCluster.prototype.execute = function(riakCommand, previous) {
     if (arguments.length === 1) {
         riakCommand.remainingTries = this.executionAttempts;
     }
+    var executing = false;
     
-    var executing = this.nodeManager.executeOnNode(this.nodes, riakCommand, previous);
-    
-    if (!executing) {
-        riakCommand.onError('No RiakNodes available to execute command.');
+    if (this._commandQueue.length === 0) {
+        executing = this.nodeManager.executeOnNode(this.nodes, riakCommand, previous);
     }
     
+    if (!executing) {
+        if (this.queueCommands) {
+            if (this.queueMaxDepth && (this._commandQueue.length >= this.queueMaxDepth)) {
+                riakCommand.onError("No RiakNodes available and command queue at maxDepth");
+            } else {
+                this._commandQueue.push(riakCommand);
+                if (this.state === State.RUNNING) {
+                    this.state = State.QUEUEING;
+                    logger.info('[RiakCluster] queueing commands.');
+                    this.emit('stateChange', this.state);
+                }
+                setTimeout(this._submitFromQueue.bind(this), 500);
+            }
+        } else {
+            riakCommand.onError('No RiakNodes available to execute command.');
+        }
+    }
+    
+};
+
+RiakCluster.prototype._submitFromQueue = function() {
+  
+    if (this.state < State.SHUTTING_DOWN) {
+        
+        var command;
+        var executing;
+        while(this._commandQueue.length) {
+            command = this._commandQueue.shift();
+            executing = this.nodeManager.executeOnNode(this.nodes, command);
+            if (!executing) {
+                this._commandQueue.unshift(command);
+                setTimeout(this._submitFromQueue.bind(this), 500);
+                break;
+            }
+        }
+        
+        if (!this._commandQueue.length) {
+            this.state = State.RUNNING;
+            logger.info('[RiakCluster] cleared command queue.');
+            this.emit('stateChange', this.state);
+        }
+    }
 };
 
 /**
@@ -255,9 +307,10 @@ RiakCluster.prototype._stateCheck = function(allowedStates) {
  * @final
  */
 var State = Object.freeze({ CREATED : 0, 
-                            RUNNING : 1, 
-                            SHUTTING_DOWN : 2, 
-                            SHUTDOWN : 3});
+                            RUNNING : 1,
+                            QUEUEING: 2, 
+                            SHUTTING_DOWN : 3, 
+                            SHUTDOWN : 4});
 
 var defaultRiakNode = new RiakNode();
 var defaultExecutionAttempts = 3;
@@ -266,8 +319,9 @@ var defaultNodeManager = new DefaultNodeManager();
 var schema = Joi.object().keys({
     nodes: Joi.array().min(1).default([defaultRiakNode]),
     executionAttempts: Joi.number().min(1).default(defaultExecutionAttempts),
-    nodeManager: Joi.object().default(defaultNodeManager)
-    
+    nodeManager: Joi.object().default(defaultNodeManager),
+    queueCommands: Joi.boolean().default(false),
+    queueMaxDepth: Joi.number().default(0)
 });
 
 /**
@@ -343,6 +397,27 @@ Builder.prototype = {
      */
     withNodeManager : function(nodeManager) {
         this.nodeManager = nodeManager;
+        return this;
+    },
+    /**
+     * Set whether to queue commands or not if no RiakNodes are available.
+     * 
+     * If all nodes are down (health checking) or maxConnections are in use on
+     * all nodes, the default behavior is to fail commands when submitted. 
+     * 
+     * Setting this option causes the the RiakCluster to queue additional commands
+     * (FIFO) then send them when nodes/connections become available. 
+     * 
+     * If maxDepth is supplied the queue is bounded and additional commands 
+     * attempting to be queued will be failed. The default is an unbounded queue.
+     * 
+     * @method withQueueCommands
+     * @param {Number} [maxDepth=unlimited] the maximum number of commands to queue. Default is unlimited.
+     * @chainable
+     */
+    withQueueCommands : function(maxDepth) {
+        this.queueCommands = true;
+        this.queueMaxDepth = maxDepth;
         return this;
     },
     /**

--- a/lib/core/riaknode.js
+++ b/lib/core/riaknode.js
@@ -99,7 +99,6 @@ function RiakNode(options) {
     });
     
     this._available = new LinkedList();
-    this._consecutiveConnectFailures = 0;
     this._currentNumConnections = 0;
     
 }
@@ -145,14 +144,12 @@ RiakNode.prototype._createNewConnection = function(postConnectFunc, postFailFunc
     var self = this;
     
     conn.on('connected', function(conn) {
-        self._consecutiveConnectFailures = 0;
         conn.on('responseReceived', self._responseReceived.bind(self));
         conn.on('connectionClosed', self._connectionClosed.bind(self));
         postConnectFunc(conn);
     });
         
     conn.on('connectFailed', function(conn, err){
-       self._consecutiveConnectFailures++;
        self._currentNumConnections--;
        postFailFunc(err);
     });
@@ -205,43 +202,46 @@ RiakNode.prototype._shutdown = function() {
  */
 RiakNode.prototype.execute = function(command) {
     this._stateCheck([State.RUNNING, State.HEALTH_CHECKING]);
-    var conn = this._available.shift();
-    var self = this;
-    // conn will be undefined if there's no available connections.
-    if (!conn) {
-        if (this._currentNumConnections < this.maxConnections) {
-            
-            this._createNewConnection(function(newConn) { 
-                logger.debug("[RiakNode] executing command '%s' on node (%s:%d)", command.PbRequestName, self.remoteAddress, self.remotePort);
-                self._consecutiveConnectFailures = 0;
-                newConn.execute(command);
-            }, function(err) {
-                logger.debug("[RiakNode] command execution failed on node (%s:%d)", self.remoteAddress, self.remotePort);
-                if (self._consecutiveConnectFailures > 5 && 
-                        self.state === State.RUNNING) {
-                    self.state = State.HEALTH_CHECKING;
-                    setImmediate(function() { self._healthCheck(); });
-                }
-                command.remainingTries--;
-                if (command.remainingTries) {
-                    self.emit('retryCommand', command, self);
-                } else {
-                    command.onError(err);
-                }
-            });
-            
-            return true;
-            
+    
+    if (this.state === State.RUNNING) {
+        var conn = this._available.shift();
+        var self = this;
+        // conn will be undefined if there's no available connections.
+        if (!conn) {
+            if (this._currentNumConnections < this.maxConnections) {
+
+                this._createNewConnection(function(newConn) { 
+                    logger.debug("[RiakNode] executing command '%s' on node (%s:%d)", command.PbRequestName, self.remoteAddress, self.remotePort);
+                    newConn.execute(command);
+                }, function(err) {
+                    logger.debug("[RiakNode] command execution failed on node (%s:%d)", self.remoteAddress, self.remotePort);
+                    if (self.state === State.RUNNING) {
+                        self.state = State.HEALTH_CHECKING;
+                        self.emit('stateChange', self, self.state);
+                        setImmediate(function() { self._healthCheck(); });
+                    }
+                    command.remainingTries--;
+                    if (command.remainingTries) {
+                        self.emit('retryCommand', command, self);
+                    } else {
+                        command.onError(err);
+                    }
+                });
+
+                return true;
+
+            } else {
+                logger.debug('[RiakNode] node (%s:%d): all connections in use and at max', this.remoteAddress, this.remotePort);
+                return false;
+            }
         } else {
-            logger.debug('[RiakNode] node (%s:%d): all connections in use and at max', this.remoteAddress, this.remotePort);
-            return false;
+            logger.debug("[RiakNode] executing command '%s' on node (%s:%d)", command.PbRequestName, this.remoteAddress, this.remotePort);
+            conn.execute(command);
+            return true;
         }
     } else {
-        logger.debug("[RiakNode] executing command '%s' on node (%s:%d)", command.PbRequestName, this.remoteAddress, this.remotePort);
-        conn.execute(command);
-        return true;
+        return false;
     }
-        
 };
 
 RiakNode.prototype._responseReceived = function(conn, command, code, decoded) {


### PR DESCRIPTION
You can now choose to queue commands in RiakCluster if there are no
RiakNodes available. Supports bounded and unbounded queue.

unit tests included.