### PR TITLE
Fix check to determine if Riak should generate key or not.

### DIFF
--- a/lib/commands/crdt/updatecounter.js
+++ b/lib/commands/crdt/updatecounter.js
@@ -86,7 +86,7 @@ UpdateCounter.prototype.constructPbRequest = function() {
     protobuf.setType(new Buffer(this.options.bucketType));
 
     // key can be null to have Riak generate it.
-    if (this.options.key !== null) {
+    if (this.options.key) {
         protobuf.setKey(new Buffer(this.options.key));
     }
 

--- a/lib/commands/crdt/updatemap.js
+++ b/lib/commands/crdt/updatemap.js
@@ -110,7 +110,7 @@ UpdateMap.prototype.constructPbRequest = function() {
     protobuf.setBucket(new Buffer(this.options.bucket));
     protobuf.setType(new Buffer(this.options.bucketType));
     // key can be null to have Riak generate it.
-    if (this.options.key !== null) {
+    if (this.options.key) {
         protobuf.setKey(new Buffer(this.options.key));
     }
 


### PR DESCRIPTION
`this.options.key !== null` returns true when `options` does not have a `key` property, due to `undefined` being the value.

This brings these files in-line with the rest of the code, which is correct.