### PR TITLE
Fixed the link to the examples repository in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for being part of the community! We love you for it.
 
 ## Helping through sample code
 
-The most immediately helpful way you can benefit this project is by cloning the [examples repository](https://github.com/basho/riak-nodejs-client-examples), make some changes and submit a pull request.
+The most immediately helpful way you can benefit this project is by cloning the [examples repository](https://github.com/basho/riak-nodejs-client-examples/), make some changes and submit a pull request.
 
 ## How-to contribute to the Node.js client
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for being part of the community! We love you for it.
 
 ## Helping through sample code
 
-The most immediately helpful way you can benefit this project is by cloning the [samples repository](https://github.com/basho-labs/riak-nodejs-client-samples/), make some changes and submit a pull request.
+The most immediately helpful way you can benefit this project is by cloning the [examples repository](https://github.com/basho/riak-nodejs-client-examples), make some changes and submit a pull request.
 
 ## How-to contribute to the Node.js client
 


### PR DESCRIPTION
The link to code samples is still pointing to https://github.com/basho-labs/riak-nodejs-client-samples/, which doesn't exist. From what I can see, the correct repo is https://github.com/basho/riak-nodejs-client-examples/.