### PR TITLE
support get/set of object content_encoding

### DIFF
--- a/lib/commands/kv/riakobject.js
+++ b/lib/commands/kv/riakobject.js
@@ -143,6 +143,27 @@ RiakObject.prototype = {
         return this.contentType;
     },
     /**
+     * Set the content encoding.
+     *
+     * @method setContentEncoding
+     * @param {String} contentEncoding the content encoding
+     * @chainable
+     */
+    setContentEncoding : function(contentEncoding) {
+        this.contentEncoding = contentEncoding;
+        return this;
+    },
+    /**
+     * Get the content encoding
+     *
+     * @method getContentEncoding
+     * @returns {String} the content encoding
+     */
+    getContentEncoding : function() {
+        return this.contentEncoding;
+    },
+
+    /**
      * Set the user meta data.
      * 
      * This is an array of key/value objects.
@@ -348,6 +369,10 @@ module.exports.createFromRpbContent = function(rpbContent, convertToJs) {
     if (rpbContent.getContentType()) {
         ro.contentType = rpbContent.getContentType().toString('utf8');
     }
+
+    if (rpbContent.getContentEncoding()) {
+        ro.contentEncoding = rpbContent.getContentEncoding().toString('utf8');
+    }
     
     if (rpbContent.getLastMod()) {
         var lm = rpbContent.getLastMod();
@@ -435,6 +460,10 @@ module.exports.populateRpbContentFromRiakObject = function(ro) {
     
     if (ro.getContentType()) {
         rpbContent.setContentType(new Buffer(ro.getContentType()));
+    }
+
+    if (ro.getContentEncoding()) {
+        rpbContent.setContentEncoding(new Buffer(ro.getContentEncoding()));
     }
 
     var i, pair;


### PR DESCRIPTION
We use the content encoding field when storing compressed objects in Riak. This is currently supported in RiakPBC client (https://github.com/nlf/riakpbc), which we are moving from.

I have added the field and raised an issues for this: https://github.com/basho/riak-nodejs-client/issues/69