### PR TITLE
Remove some duplicate code.

### DIFF
--- a/lib/core/riaknode.js
+++ b/lib/core/riaknode.js
@@ -220,9 +220,7 @@ RiakNode.prototype.execute = function(command) {
                 }, function(err) {
                     logger.debug("[RiakNode] command execution failed on node (%s:%d)", self.remoteAddress, self.remotePort);
                     if (self.state === State.RUNNING) {
-                        self.state = State.HEALTH_CHECKING;
-                        self.emit(EVT_SC, self, self.state);
-                        setImmediate(function() { self._healthCheck(); });
+                        self._doHealthCheck();
                     }
                     command.remainingTries--;
                     if (command.remainingTries) {
@@ -321,12 +319,7 @@ RiakNode.prototype._connectionClosed = function(conn) {
         // PB connections don't time out. If one disconnects it's highly likely
         // the node went down or there's a network issue
         if (this.state !== State.HEALTH_CHECKING) {
-            this.state = State.HEALTH_CHECKING;
-            this.emit(EVT_SC, this, this.state);
-            var self = this;
-            setImmediate(function() {
-                self._healthCheck();
-            });
+            this._doHealthCheck();
         }
     }
 };
@@ -335,6 +328,12 @@ RiakNode.prototype._stateCheck = function(allowedStates) {
     if (allowedStates.indexOf(this.state) === -1) {
         throw "RiakNode: Illegal State; required: " + allowedStates + " current: " + this.state; 
     }
+};
+
+RiakNode.prototype._doHealthCheck = function() {
+    this.state = State.HEALTH_CHECKING;
+    this.emit(EVT_SC, this, this.state);
+    setImmediate(this._healthCheck.bind(this));
 };
 
 RiakNode.prototype._healthCheck = function() {

--- a/test/integration/core/riaknode.js
+++ b/test/integration/core/riaknode.js
@@ -57,9 +57,6 @@ describe('RiakNode - Integration', function() {
                 done();
             }, 3000); 
             
-            
-            
-            
             var node = new RiakNode.Builder()
                     .withRemotePort(1337)
                     .withMinConnections(0)
@@ -175,8 +172,6 @@ describe('RiakNode - Integration', function() {
             
             var fetch = new FetchValue({bucket: 'b', key: 'k'}, fetchCb);
             node.execute(fetch);
-            
-            
             
         });
         


### PR DESCRIPTION
Remove duplicate code found when reviewing riaknode.js while working on Go client.