### PR TITLE
return empty object for tombstone

### DIFF
--- a/lib/commands/kv/riakobject.js
+++ b/lib/commands/kv/riakobject.js
@@ -360,7 +360,7 @@ module.exports.createFromRpbContent = function(rpbContent, convertToJs) {
     
     // ReturnHead will only retun metadata
     if (convertToJs && value) {
-        ro.value = JSON.parse(value.toString('utf8'));
+        ro.value = rpbContent.deleted?{}:JSON.parse(value.toString('utf8')); 
     } else if (value) {
         ro.value = value.toBuffer();
     }


### PR DESCRIPTION
I'm not sure if this is the correct behavior, but this is a fix for JIRA: CLIENTS-493 (#74). I just return an empty object in the case a tombstone is found. Otherwise, the JSON parser fails on the value. 