### PR TITLE
Parameterize the queue submit interval of RiakCluster

### DIFF
--- a/lib/core/riakcluster.js
+++ b/lib/core/riakcluster.js
@@ -202,8 +202,7 @@ RiakCluster.prototype.execute = function(riakCommand, previous) {
                 if (this.state === State.RUNNING) {
                     this.state = State.QUEUEING;
 
-                    // TODO: should this timeout be configurable, or based on an
-                    // average command execution time? Used for rate-limiting
+                    // TODO: should this timeout be average command execution time? Used for rate-limiting
                     setTimeout(this._submitFromQueue.bind(this), this.queueSubmitInterval);
                     logger.info('[RiakCluster] queueing commands.');
                     this.emit(EVT_SC, this.state);
@@ -229,8 +228,7 @@ RiakCluster.prototype._submitFromQueue = function() {
 				// TODO: this does not take retries into account, so a command that continually
 				// errors could back up the queue indefinitely
                 this._commandQueue.unshift(command);
-                // TODO: should this timeout be configurable, or based on an
-                // average command execution time?
+                // TODO: should this timeout be based on an average command execution time?
                 setTimeout(this._submitFromQueue.bind(this), this.queueSubmitInterval);
                 break;
             }

--- a/lib/core/riakcluster.js
+++ b/lib/core/riakcluster.js
@@ -61,7 +61,8 @@ var LinkedList = require('linkedlist');
  * @param {Object} [options.nodeManager=DefaultNodeManager] Set the NodeManager for this cluster.
  * @param {Boolean} [options.queueCommands=false] Set whether to queue commands or not if no RiakNodes are available.
  * @param {Number} [options.queueMaxDepth=unlimited] The maximum number of commands to queue if queueCommands is set. Default is unlimited.
- * 
+ * @param {Number} [options.queueSubmitInterval=500] The duration in milliseconds between queue submission attempts. Default is 500.
+ *
  */
 function RiakCluster(options) {
 
@@ -83,6 +84,7 @@ function RiakCluster(options) {
         self.nodeManager = options.nodeManager;
         self.queueCommands = options.queueCommands;
         self.queueMaxDepth = options.queueMaxDepth;
+        self.queueSubmitInterval = options.queueSubmitInterval;
     });
 
     this._commandQueue = new LinkedList();
@@ -202,7 +204,7 @@ RiakCluster.prototype.execute = function(riakCommand, previous) {
 
                     // TODO: should this timeout be configurable, or based on an
                     // average command execution time? Used for rate-limiting
-                    setTimeout(this._submitFromQueue.bind(this), 500);
+                    setTimeout(this._submitFromQueue.bind(this), this.queueSubmitInterval);
                     logger.info('[RiakCluster] queueing commands.');
                     this.emit(EVT_SC, this.state);
                 }
@@ -229,7 +231,7 @@ RiakCluster.prototype._submitFromQueue = function() {
                 this._commandQueue.unshift(command);
                 // TODO: should this timeout be configurable, or based on an
                 // average command execution time?
-                setTimeout(this._submitFromQueue.bind(this), 500);
+                setTimeout(this._submitFromQueue.bind(this), this.queueSubmitInterval);
                 break;
             }
         }
@@ -344,7 +346,8 @@ var schema = Joi.object().keys({
     nodeManager: Joi.object()
         .default(createDefaultNodeManager, 'default is a new instance of DefaultNodeManager'),
     queueCommands: Joi.boolean().default(false),
-    queueMaxDepth: Joi.number().default(0)
+    queueMaxDepth: Joi.number().default(0),
+    queueSubmitInterval: Joi.number().default(500)
 });
 
 /**
@@ -438,11 +441,13 @@ Builder.prototype = {
      * 
      * @method withQueueCommands
      * @param {Number} [maxDepth=unlimited] the maximum number of commands to queue. Default is unlimited.
+     * @param {Number} [submitInterval=500] The duration in milliseconds between queue submission attempts. Default is 500.
      * @chainable
      */
-    withQueueCommands : function(maxDepth) {
+    withQueueCommands : function(maxDepth, submitInterval) {
         this.queueCommands = true;
         this.queueMaxDepth = maxDepth;
+        this.queueSubmitInterval = submitInterval;
         return this;
     },
     /**


### PR DESCRIPTION
Have RiakCluster take a parameter for the queue submission interval, previously hard coded to 500ms.