### PR TITLE
Ready: Use new timeseries float/double apis

### DIFF
--- a/lib/commands/ts/data.js
+++ b/lib/commands/ts/data.js
@@ -6,7 +6,7 @@ var validColumnTypes = Object.freeze([0, 1, 2, 3, 4, 5, 6]);
 var ColumnType = Object.freeze({
     Binary:    TsColumnType.BINARY,
     Integer:   TsColumnType.INTEGER,
-    Numeric:   TsColumnType.NUMERIC,
+    Float:   TsColumnType.FLOAT,
     Timestamp: TsColumnType.TIMESTAMP,
     Boolean:   TsColumnType.BOOLEAN,
     Set:       TsColumnType.SET,

--- a/lib/commands/ts/data.js
+++ b/lib/commands/ts/data.js
@@ -6,7 +6,7 @@ var validColumnTypes = Object.freeze([0, 1, 2, 3, 4, 5, 6]);
 var ColumnType = Object.freeze({
     Binary:    TsColumnType.BINARY,
     Integer:   TsColumnType.INTEGER,
-    Float:   TsColumnType.FLOAT,
+    Float:     TsColumnType.FLOAT,
     Timestamp: TsColumnType.TIMESTAMP,
     Boolean:   TsColumnType.BOOLEAN,
     Set:       TsColumnType.SET,

--- a/lib/commands/ts/query.js
+++ b/lib/commands/ts/query.js
@@ -117,13 +117,8 @@ Query.prototype.onSuccess = function(rpbQueryResp) {
                         case TsColumnType.INTEGER:
                             rsprow.push(rcell.getIntegerValue());
                             break;
-                        case TsColumnType.NUMERIC:
-                            var numericValue = rcell.getNumericValue();
-                            if (numericValue) {
-                                rsprow.push(numericValue.toString('utf8'));
-                            } else {
-                                rsprow.push(null);
-                            }
+                        case TsColumnType.FLOAT:
+                            rsprow.push(rcell.getDoubleValue());
                             break;
                         case TsColumnType.TIMESTAMP:
                             rsprow.push(rcell.getTimestampValue());

--- a/lib/commands/ts/storevalue.js
+++ b/lib/commands/ts/storevalue.js
@@ -145,11 +145,7 @@ StoreValue.prototype.constructPbRequest = function() {
                             tsc.setIntegerValue(cell);
                             break;
                         case TsColumnType.FLOAT:
-                            if(utils.isString(cell)) {
-                                tsc.setNumericValue(new Buffer(cell.toString()));
-                            } else if(isFloat(cell)) {
-                                tsc.setDoubleValue(cell);    
-                            } 
+                            tsc.setDoubleValue(cell);
                             break;
                         case TsColumnType.TIMESTAMP:
                             // NB: must be convertible to Long to serialize as sint64

--- a/lib/commands/ts/storevalue.js
+++ b/lib/commands/ts/storevalue.js
@@ -144,8 +144,12 @@ StoreValue.prototype.constructPbRequest = function() {
                             // NB: must be convertible to Long to serialize as sint64
                             tsc.setIntegerValue(cell);
                             break;
-                        case TsColumnType.NUMERIC:
-                            tsc.setNumericValue(new Buffer(cell.toString()));
+                        case TsColumnType.FLOAT:
+                            if(utils.isString(cell)) {
+                                tsc.setNumericValue(new Buffer(cell.toString()));
+                            } else if(isFloat(cell)) {
+                                tsc.setDoubleValue(cell);    
+                            } 
                             break;
                         case TsColumnType.TIMESTAMP:
                             // NB: must be convertible to Long to serialize as sint64
@@ -195,7 +199,7 @@ StoreValue.prototype.constructPbRequest = function() {
                     } else if (isInteger(cell)) {
                         tsc.setIntegerValue(cell);
                     } else if (isFloat(cell)) {
-                        tsc.setNumericValue(new Buffer(cell.toString()));
+                        tsc.setDoubleValue(cell);
                     } else if (isObject(cell)) {
                         tsc.setMapValue(new Buffer(JSON.stringify(cell)));
                     }

--- a/test/integration/ts/timeseries.js
+++ b/test/integration/ts/timeseries.js
@@ -30,7 +30,7 @@ var columns = [
     { name: 'user',        type: TS.ColumnType.Binary },
     { name: 'time',        type: TS.ColumnType.Timestamp },
     { name: 'weather',     type: TS.ColumnType.Binary },
-    { name: 'temperature', type: TS.ColumnType.Numeric }
+    { name: 'temperature', type: TS.ColumnType.Float }
 ];
 
 // TODO FUTURE - when this PR is accepted, it will be OK to have

--- a/test/integration/ts/timeseries.js
+++ b/test/integration/ts/timeseries.js
@@ -38,7 +38,7 @@ var columns = [
 // https://github.com/basho/riak_pb/pull/135
 var rows = [
     [ 'hash1', 'user2', twentyMinsAgo, 'cloudy', null ],
-    [ 'hash1', 'user2', fifteenMinsAgo, 'rain', '79.0' ],
+    [ 'hash1', 'user2', fifteenMinsAgo, 'rain', 79.0 ],
     [ 'hash1', 'user2', fiveMinsAgo, 'wind', 50.5 ],
     [ 'hash1', 'user2', now, 'snow', 20.1 ]
 ];

--- a/test/unit/ts/data.js
+++ b/test/unit/ts/data.js
@@ -13,7 +13,7 @@ var Long = require('long');
 var columns = [
     { name: 'col_binary',    type: TS.ColumnType.Binary },
     { name: 'col_int',       type: TS.ColumnType.Integer },
-    { name: 'col_numeric',   type: TS.ColumnType.Numeric },
+    { name: 'col_float',   type: TS.ColumnType.Float },
     { name: 'col_timestamp', type: TS.ColumnType.Timestamp },
     { name: 'col_boolean',   type: TS.ColumnType.Boolean },
     { name: 'col_set',       type: TS.ColumnType.Set },
@@ -84,10 +84,8 @@ for (var i = 0; i < rows.length; i++) {
             case TS.ColumnType.Integer:
                 cell.setIntegerValue(val);
                 break;
-            case TS.ColumnType.Numeric:
-                if (val) {
-                    cell.setNumericValue(new Buffer(val.toString()));
-                }
+            case TS.ColumnType.Float:
+                    cell.setDoubleValue(val);
                 break;
             case TS.ColumnType.Timestamp:
                 if (val) {

--- a/test/unit/ts/query.js
+++ b/test/unit/ts/query.js
@@ -59,9 +59,9 @@ describe('Query', function() {
                 assert.strictEqual(rc[1].name, 'col_int');
                 assert.strictEqual(rc[1].type, TsColumnType.INTEGER);
                 assert.strictEqual(rc[1].type, TS.ColumnType.Integer);
-                assert.strictEqual(rc[2].name, 'col_numeric');
-                assert.strictEqual(rc[2].type, TsColumnType.NUMERIC);
-                assert.strictEqual(rc[2].type, TS.ColumnType.Numeric);
+                assert.strictEqual(rc[2].name, 'col_float');
+                assert.strictEqual(rc[2].type, TsColumnType.FLOAT);
+                assert.strictEqual(rc[2].type, TS.ColumnType.Float);
                 assert.strictEqual(rc[3].name, 'col_timestamp');
                 assert.strictEqual(rc[3].type, TsColumnType.TIMESTAMP);
                 assert.strictEqual(rc[3].type, TS.ColumnType.Timestamp);
@@ -85,7 +85,7 @@ describe('Query', function() {
                 assert(r0[0] instanceof Buffer);
                 assert(d.bd0.equals(r0[0]));
                 assert(r0[1].equals(Long.ZERO));
-                assert.strictEqual(r0[2], '1.2');
+                assert.strictEqual(r0[2], 1.2);
                 assert(r0[3] instanceof Long);
                 assert(d.ts0ms.equals(r0[3]));
                 assert.strictEqual(r0[4], true);
@@ -97,7 +97,7 @@ describe('Query', function() {
                 assert(r1[0] instanceof Buffer);
                 assert(d.bd1.equals(r1[0]));
                 assert(r1[1].equals(3));
-                assert.strictEqual(r1[2], '4.5');
+                assert.strictEqual(r1[2], 4.5);
                 assert(r1[3] instanceof Long);
                 assert(d.ts1ms.equals(r1[3]));
                 assert.strictEqual(r1[4], false);
@@ -108,7 +108,7 @@ describe('Query', function() {
                 var r2 = rr[2];
                 assert.strictEqual(r2[0], null);
                 assert(r2[1].equals(6));
-                assert.strictEqual(r2[2], '7.8');
+                assert.strictEqual(r2[2], 7.8);
                 assert.strictEqual(r2[3], null);
                 assert.strictEqual(r2[4], false);
                 assert.deepStrictEqual(r2[5], []);

--- a/test/unit/ts/storevalue.js
+++ b/test/unit/ts/storevalue.js
@@ -31,8 +31,8 @@ function validateTsPutReq(protobuf, hasCols) {
         assert.strictEqual(col1.getType(), TsColumnType.INTEGER);
 
         var col2 = pcols[2];
-        assert.strictEqual(col2.getName().toString('utf8'), 'col_numeric');
-        assert.strictEqual(col2.getType(), TsColumnType.NUMERIC);
+        assert.strictEqual(col2.getName().toString('utf8'), 'col_float');
+        assert.strictEqual(col2.getType(), TsColumnType.FLOAT);
 
         var col3 = pcols[3];
         assert.strictEqual(col3.getName().toString('utf8'), 'col_timestamp');
@@ -63,7 +63,7 @@ function validateTsPutReq(protobuf, hasCols) {
 
     assert(d.bd0.equals(row0cells[0].getBinaryValue().toBuffer()));
     assert(row0cells[1].getIntegerValue().equals(Long.ZERO));
-    assert.strictEqual(row0cells[2].getNumericValue().toString('utf8'), '1.2');
+    assert.strictEqual(row0cells[2].getDoubleValue(), 1.2);
     // ts0 is a Date
     var r0c3tsv = row0cells[3].getTimestampValue();
     assert(d.ts0ms.equals(r0c3tsv));
@@ -94,7 +94,7 @@ function validateTsPutReq(protobuf, hasCols) {
 
     assert(d.bd1.equals(row1cells[0].getBinaryValue().toBuffer()));
     assert(row1cells[1].getIntegerValue().equals(three));
-    assert.strictEqual(row1cells[2].getNumericValue().toString('utf8'), '4.5');
+    assert.strictEqual(row1cells[2].getDoubleValue(), 4.5);
 
     var r1c3tsv = row1cells[3].getTimestampValue();
     assert(d.ts1ms.equals(r1c3tsv));


### PR DESCRIPTION
Rework client to use new float/double api for cells. Swap "Numeric" column type for "Float". 