### PR TITLE
uncaught exception

### DIFF
--- a/lib/core/riaknode.js
+++ b/lib/core/riaknode.js
@@ -562,7 +562,7 @@ RiakNode.prototype._connectionClosed = function (conn) {
     // See if a command was being handled
     var command = conn.command;
     logger.debug("%s connection closed; command '%s', in-flight: '%s'",
-        this.name, command.name, conn.inFlight);
+        this.name, command.name || 'undefined', conn.inFlight);
     if (conn.inFlight) {
         this.executeCount--;
         this._maybeRetryCommand(command, function () {


### PR DESCRIPTION
My logs show several occurrences of the following error:
```
node-app[XXX]: error: UNCAUGHT EXCEPTION TypeError: Cannot read property 'name' of undefined#012    at RiakNode._connectionClosed (/usr/share/XXX/Staging-d-O79Y6AIIG/node_modules/basho-riak-client/lib/core/riaknode.js:565:27)#012    at emitTwo (events.js:106:13)#012    at RiakConnection.emit (events.js:191:7)#012    at RiakConnection._emitAndClose (/usr/share/XXX/Staging-d-O79Y6AIIG/node_modules/basho-riak-client/lib/core/riakconnection.js:137:18)#012    at RiakConnection._connHandleEnd (/usr/share/XXX/Staging-d-O79Y6AIIG/node_modules/basho-riak-client/lib/core/riakconnection.js:144:14)#012    at emitNone (events.js:91:20)#012    at Socket.emit (events.js:185:7)#012    at endReadableNT (_stream_readable.js:934:12)#012    at _combinedTickCallback (internal/process/next_tick.js:74:11)#012    at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```

I assume, from the comment a couple lines above, that command / command.name may be undefined, which may cause these uncaught exceptions.

Let me know if you need an issue or anything.