### PR TITLE
Fix for undefined exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ Thank you to all of our contributors!
 * [Gabriel Nicolas Avellaneda](https://github.com/GabrielNicolasAvellaneda)
 * [Iain Proctor](https://github.com/iproctor)
 * [Brian Edgerton](https://github.com/brianedgerton)
+* [Samuel](https://github.com/faust64)

--- a/RELNOTES.md
+++ b/RELNOTES.md
@@ -1,6 +1,8 @@
 Release Notes
 =============
 
+* [2.2.1](https://github.com/basho/riak-nodejs-client/issues?q=milestone%3Ariak-nodejs-client-2.2.1) - Following issues / PRs addressed:
+ * [Fix uncaught exception when connection closes on a connection that had never executed a command](https://github.com/basho/riak-nodejs-client/pull/163)
 * [2.2.0](https://github.com/basho/riak-nodejs-client/issues?q=milestone%3Ariak-nodejs-client-2.2.0) - Following issues / PRs addressed:
  * [Support load balancers](https://github.com/basho/riak-nodejs-client/issues/151) ([PR](https://github.com/basho/riak-nodejs-client/pull/152))
  * [Implement read / write timeouts](https://github.com/basho/riak-nodejs-client/pull/145)

--- a/lib/core/riakconnection.js
+++ b/lib/core/riakconnection.js
@@ -98,34 +98,6 @@ function RiakConnection(options) {
         initBufferSize = options.initBufferSize;
     }
 
-    this.inFlight = false;
-    this.lastUsed = Date.now();
-
-    this.closed = false;
-    this._connectedEmitted = false;
-
-    this._connection = new net.Socket();
-    if (this._connection.setKeepAlive) {
-        this._connection.setKeepAlive(true, 0);
-    }
-    if (this._connection.setNoDelay) {
-        this._connection.setNoDelay(true);
-    }
-
-    // Note: useful for debugging event issues
-    /*
-    debugOutputConnectionListeners(this.name, this._connection);
-    this.setMaxListeners(1);
-    this._connection.setMaxListeners(1);
-    */
-
-    if (this.cork && !this._connection.cork) {
-        logger.warn('%s wanted to use cork/uncork but not supported!', this.name);
-        this.cork = false;
-    } else {
-        logger.debug('%s using cork() / uncork()', this.name);
-    }
-
     this._emitAndClose = function(evt, evt_args) {
         if (!this.closed) {
             // NB: this can be useful
@@ -251,6 +223,46 @@ function RiakConnection(options) {
         initBuffer(data);
         return getProtobufsFromBuffer();
     };
+
+    // protected execute functions
+    this._executeInit = function() {
+        this.lastUsed = Date.now();
+        this.executeDone();
+    };
+
+    this._executeStart = function(command) {
+        this.command = command;
+        logger.debug('%s execute command:', this.name, command.name);
+        this.inFlight = true;
+        this.lastUsed = Date.now();
+    };
+
+    this._executeInit();
+
+    this.closed = false;
+    this._connectedEmitted = false;
+
+    this._connection = new net.Socket();
+    if (this._connection.setKeepAlive) {
+        this._connection.setKeepAlive(true, 0);
+    }
+    if (this._connection.setNoDelay) {
+        this._connection.setNoDelay(true);
+    }
+
+    // Note: useful for debugging event issues
+    /*
+    debugOutputConnectionListeners(this.name, this._connection);
+    this.setMaxListeners(1);
+    this._connection.setMaxListeners(1);
+    */
+
+    if (this.cork && !this._connection.cork) {
+        logger.warn('%s wanted to use cork/uncork but not supported!', this.name);
+        this.cork = false;
+    } else {
+        logger.debug('%s using cork() / uncork()', this.name);
+    }
 }
 
 util.inherits(RiakConnection, events.EventEmitter);
@@ -477,24 +489,24 @@ RiakConnection.prototype.close = function() {
     logger.debug('%s closed', this.name);
 };
 
-RiakConnection.prototype.executeDone = function(command) {
+RiakConnection.prototype.executeDone = function() {
     this.inFlight = false;
+    this.command = {
+        name: 'no-command'
+    };
     this._resetBuffer();
 };
 
 // command includes user callback
 RiakConnection.prototype.execute = function(command) {
-    this.command = command;
-
     if (this.inFlight === true) {
         logger.error('%s attempted to run command "%s" on in-use connection',
             this.name, command.name);
         return false;
     }
 
-    logger.debug('%s execute command:', this.name, command.name);
-    this.inFlight = true;
-    this.lastUsed = Date.now();
+    this._executeStart(command);
+
     // write PB to socket
     var message = command.getRiakMessage();
 

--- a/lib/core/riaknode.js
+++ b/lib/core/riaknode.js
@@ -561,8 +561,10 @@ RiakNode.prototype._connectionClosed = function (conn) {
     this._decrementConnectionCount();
     // See if a command was being handled
     var command = conn.command;
-    logger.debug("%s connection closed; command '%s', in-flight: '%s'",
-        this.name, command.name || 'undefined', conn.inFlight);
+    logger.debug("%s connection closed; command: '%s', in-flight: '%s'",
+        this.name, command.name, conn.inFlight);
+    // NB: if there is no executing command on this connection,
+    // inFlight will be false
     if (conn.inFlight) {
         this.executeCount--;
         this._maybeRetryCommand(command, function () {

--- a/lib/core/riaknode.js
+++ b/lib/core/riaknode.js
@@ -139,12 +139,16 @@ function RiakNode(options) {
                 this.name, available.length, currentNumConnections);
         } else {
             logger.debug('%s connection returned to pool during shutdown.', this.name);
-            currentNumConnections--;
+            this._decrementConnectionCount();
             conn.close();
         }
     };
 
     this._decrementConnectionCount = function () {
+        if ((currentNumConnections - 1) < 0) {
+            logger.debug("%s cnc will decrement less than zero! (%d)",
+                this.name, currentNumConnections);
+        }
         currentNumConnections--;
     };
 
@@ -168,6 +172,7 @@ function RiakNode(options) {
             // NB: don't keep any closed connections around.
             if (conn.closed) {
                 conn.executeDone();
+                conn = null;
                 continue;
             }
 
@@ -184,7 +189,7 @@ function RiakNode(options) {
             }
 
             if ((now - conn.lastUsed) >= idleTimeout) {
-                currentNumConnections--;
+                this._decrementConnectionCount();
                 conn.close();
                 count++;
                 continue;
@@ -231,7 +236,7 @@ function RiakNode(options) {
         conn.on('connectFailed', function (conn, err){
             // NB: when connectFailed is raised, conn is already closed
             logger.debug("%s conn.on-connectFailed", this.name);
-            currentNumConnections--;
+            this._decrementConnectionCount();
             postFailFunc(err);
         });
 
@@ -327,9 +332,14 @@ function RiakNode(options) {
             var conn = null;
             while (available.length) {
                 conn = available.shift();
-                currentNumConnections--;
-                conn.close();
-                conns.push(conn);
+                if (conn.closed) {
+                    conn.executeDone();
+                    conn = null;
+                } else {
+                    self._decrementConnectionCount();
+                    conn.close();
+                    conns.push(conn);
+                }
             }
             logger.debug("%s closed connections (cnc: %d)",
                 self.name, currentNumConnections);

--- a/lib/core/riaknode.js
+++ b/lib/core/riaknode.js
@@ -562,7 +562,7 @@ RiakNode.prototype._connectionClosed = function (conn) {
     // See if a command was being handled
     var command = conn.command;
     logger.debug("%s connection closed; command '%s', in-flight: '%s'",
-        this.name, command.name, conn.inFlight);
+        this.name, command.name || 'undefined', conn.inFlight);
     if (conn.inFlight) {
         this.executeCount--;
         this._maybeRetryCommand(command, function () {

--- a/lib/core/riaknode.js
+++ b/lib/core/riaknode.js
@@ -189,6 +189,7 @@ function RiakNode(options) {
             }
 
             if ((now - conn.lastUsed) >= idleTimeout) {
+                /* jshint validthis:true */
                 this._decrementConnectionCount();
                 conn.close();
                 count++;
@@ -236,7 +237,7 @@ function RiakNode(options) {
         conn.on('connectFailed', function (conn, err){
             // NB: when connectFailed is raised, conn is already closed
             logger.debug("%s conn.on-connectFailed", this.name);
-            this._decrementConnectionCount();
+            self._decrementConnectionCount();
             postFailFunc(err);
         });
 


### PR DESCRIPTION
If a connection is closed prior to any command executing on it, `conn.command` will be `undefined` in `RiakNode` and will throw an exception if `debug` logging is enabled.

Supercedes #163