### PR TITLE
Avoid TypeError: Cannot read property 'name' of undefined

### DIFF
--- a/lib/core/riaknode.js
+++ b/lib/core/riaknode.js
@@ -572,8 +572,9 @@ RiakNode.prototype._connectionClosed = function (conn) {
     this._decrementConnectionCount();
     // See if a command was being handled
     var command = conn.command;
+    var commandName = command && command.name;
     logger.debug("%s connection closed; command: '%s', in-flight: '%s'",
-        this.name, command.name, conn.inFlight);
+        this.name, commandName, conn.inFlight);
     // NB: if there is no executing command on this connection,
     // inFlight will be false
     if (conn.inFlight) {


### PR DESCRIPTION
This should fix this:

TypeError: Cannot read property 'name' of undefined
    at RiakNode._connectionClosed (/home/ec2-user/gameserver/node_modules/basho-riak-client/lib/core/riaknode.js:565:27)
    at emitTwo (events.js:87:13)
    at RiakConnection.emit (events.js:172:7)
    at RiakConnection._emitAndClose (/home/ec2-user/gameserver/node_modules/basho-riak-client/lib/core/riakconnection.js:137:18)
    at RiakConnection._connClosed (/home/ec2-user/gameserver/node_modules/basho-riak-client/lib/core/riakconnection.js:459:10)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at TCP._onclose (net.js:477:12)